### PR TITLE
ci: shared python lint, unit test, and PR title workflows + team conventions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,8 +16,8 @@
 
 ## Checklist
 
-- [] Code builds without errors
-- [] Code follows the project's code style guidelines
-- [] Tests were added for any new functionality
-- [] All tests pass
-- [] Documentation was added/updated if necessary
+- [ ] Code builds without errors
+- [ ] Code follows the project's code style guidelines
+- [ ] Tests were added for any new functionality
+- [ ] All tests pass
+- [ ] Documentation was added/updated if necessary

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,10 @@
 
 [Add a link to the related issue here, if applicable]
 
+## Related ADO Item
+
+[Add the ADO work item ID or link here, if applicable]
+
 ## Checklist
 
 - [] Code builds without errors

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,36 @@
+name: Python Lint
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: 'Python version to run Ruff under'
+        default: '3.13'
+        required: false
+        type: string
+      ruff-version:
+        description: 'Pinned Ruff version'
+        default: '0.15.6'
+        required: false
+        type: string
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install Ruff
+        run: pip install "ruff==${{ inputs.ruff-version }}"
+
+      - name: Ruff check
+        run: ruff check .
+
+      - name: Ruff format check
+        run: ruff format --check .

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -1,0 +1,111 @@
+name: Python Unit Tests
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: 'Python version to run tests under'
+        default: '3.13'
+        required: false
+        type: string
+      test-root:
+        description: 'Directory under which to discover tests'
+        default: '.'
+        required: false
+        type: string
+      test-script:
+        description: 'Optional repo-local script that replaces test discovery entirely'
+        default: ''
+        required: false
+        type: string
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Discover test directories
+        id: discover
+        run: |
+          candidates=$(find "${{ inputs.test-root }}" -type d -name tests \
+            -not -path '*/node_modules/*' -not -path '*/.venv/*' \
+            -not -path '*/test-env/*' -not -path '*/.git/*' \
+            -not -path '*/automation-tests/*')
+          dirs=""
+          while IFS= read -r d; do
+            [ -z "$d" ] && continue
+            if [ -n "$(find "$d" -name '*.py' -print -quit)" ]; then
+              dirs="${dirs}${d}"$'\n'
+            fi
+          done <<< "$candidates"
+          {
+            echo "dirs<<DIRS_EOF"
+            echo "$dirs"
+            echo "DIRS_EOF"
+          } >> "$GITHUB_OUTPUT"
+          if [ -z "$dirs" ] && [ -z "${{ inputs.test-script }}" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: No tests found (vacuous pass)
+        if: steps.discover.outputs.found == 'false'
+        run: echo "::notice::No unit tests found in this repository. The unit-test gate passes vacuously. Add tests under a tests/ directory to activate it."
+
+      - name: Install dependencies
+        if: steps.discover.outputs.found == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov pytest-mock pytest-asyncio
+          find "${{ inputs.test-root }}" -name requirements.txt \
+            -not -path '*/node_modules/*' -not -path '*/automation-tests/*' \
+            -exec pip install -r {} \;
+          find "${{ inputs.test-root }}" -name requirements-dev.txt \
+            -not -path '*/node_modules/*' -not -path '*/automation-tests/*' \
+            -exec pip install -r {} \;
+
+      - name: Run unit tests
+        if: steps.discover.outputs.found == 'true'
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        run: |
+          mkdir -p test-results
+          if [ -n "${{ inputs.test-script }}" ]; then
+            bash "${{ inputs.test-script }}"
+            exit $?
+          fi
+          layer_paths=""
+          for p in $(find . -type d -path '*/layers/*/python' -not -path '*/node_modules/*'); do
+            layer_paths="${GITHUB_WORKSPACE}/${p#./}:${layer_paths}"
+          done
+          failed=0
+          while IFS= read -r test_dir; do
+            [ -z "$test_dir" ] && continue
+            src_dir=$(dirname "$test_dir")
+            name=$(echo "$src_dir" | tr '/.' '--')
+            echo "::group::Running tests in $src_dir"
+            (cd "$src_dir" && PYTHONPATH=".:${layer_paths}${PYTHONPATH:-}" python -m pytest tests/ \
+              --junitxml="$GITHUB_WORKSPACE/test-results/$name-results.xml" --tb=short -v) || failed=1
+            echo "::endgroup::"
+          done <<< "${{ steps.discover.outputs.dirs }}"
+          exit $failed
+
+      - name: Publish test results
+        if: always() && steps.discover.outputs.found == 'true'
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: 'test-results/*.xml'
+          check_name: 'Python Unit Test Results'
+          comment_mode: always
+          fail_on: test failures

--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -22,6 +22,10 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -67,9 +71,11 @@ jobs:
           pip install pytest pytest-cov pytest-mock pytest-asyncio
           find "${{ inputs.test-root }}" -name requirements.txt \
             -not -path '*/node_modules/*' -not -path '*/automation-tests/*' \
+            -not -path '*/.venv/*' -not -path '*/test-env/*' -not -path '*/.git/*' \
             -exec pip install -r {} \;
           find "${{ inputs.test-root }}" -name requirements-dev.txt \
             -not -path '*/node_modules/*' -not -path '*/automation-tests/*' \
+            -not -path '*/.venv/*' -not -path '*/test-env/*' -not -path '*/.git/*' \
             -exec pip install -r {} \;
 
       - name: Run unit tests
@@ -86,9 +92,9 @@ jobs:
             exit $?
           fi
           layer_paths=""
-          for p in $(find . -type d -path '*/layers/*/python' -not -path '*/node_modules/*'); do
+          while IFS= read -r -d '' p; do
             layer_paths="${GITHUB_WORKSPACE}/${p#./}:${layer_paths}"
-          done
+          done < <(find . -type d -path '*/layers/*/python' -not -path '*/node_modules/*' -print0)
           failed=0
           while IFS= read -r test_dir; do
             [ -z "$test_dir" ] && continue

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -1,0 +1,26 @@
+name: Semantic PR Title
+
+on:
+  workflow_call:
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title against conventional commits
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            test
+            refactor
+            ci
+            perf
+            build
+            revert
+          requireScope: false

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   pr-title:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Validate PR title against conventional commits
         uses: amannn/action-semantic-pull-request@v5

--- a/README.md
+++ b/README.md
@@ -141,3 +141,39 @@ jobs:
       fail_if_xl: 'true'
       files_to_ignore: 'package-lock.json,yarn.lock,pnpm-lock.yaml,*.min.js'
 ```
+
+## Team Conventions (DIoTS)
+
+### PR titles: conventional commits (enforced by CI)
+
+PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/): `<type>(optional-scope): description`
+
+Allowed types: `feat` `fix` `chore` `docs` `test` `refactor` `ci` `perf` `build` `revert`
+
+Examples:
+- `feat: firmware download-url discovery API`
+- `fix(ble-scanner): apply shadow config before first scan`
+- `feat(ADO-238821): move user_provided location to config shadow`
+
+We squash-merge, so the PR title becomes the commit subject on `main`. The `Semantic PR Title` check enforces this on every PR in iot-* repos.
+
+### Branch naming (guidance, not enforced)
+
+`<type>/<ticket-or-slug>`, e.g. `feat/ADO-238821-config-shadow`, `fix/ble-scanner-boot-config`, `chore/sdlc-standardization`.
+
+### PR size
+
+The PR size labeler tags every PR (`size:xs` through `size:xl`, xl = >900 changed lines excluding lockfiles). Keep PRs under 900 lines; split stacked work into numbered PRs (see iot-firmware-management's `(1/4)`...`(4/4)` distro series for the pattern). **Planned for mid-August 2026:** `size:xl` PRs will fail the check and block merge.
+
+### ADO linkage
+
+Reference the ADO work item in the PR body (the template prompts for it). Optionally use the scope for it: `feat(ADO-12345): ...`. Not CI-enforced.
+
+### Python linting
+
+All iot-* repos lint with Ruff (rules `E`, `F`, `I`; `ruff format` for style). Config is `ruff.toml` at each repo root. Run locally with:
+
+```
+pip install ruff==0.15.6
+ruff check . && ruff format --check .
+```


### PR DESCRIPTION
## Description
Adds three reusable workflows (python-lint, python-unit-tests, semantic-pr-title) that the 7 iot-* repos will call, plus documented team conventions and an ADO line in the org PR template.

Part of the iot-* SDLC standardization effort (spec: local, ask Andrew).

## Changes Made
- `python-lint.yml`: Ruff check + format check, pinned 0.15.6
- `python-unit-tests.yml`: pytest auto-discovery, layer PYTHONPATH handling, vacuous pass with notice when no tests exist
- `semantic-pr-title.yml`: conventional-commit PR title validation
- README: team conventions (titles, branches, PR size, ADO linkage, linting)
- PR template: Related ADO Item section

## Related ADO Item
[fill in]