### PR TITLE
fix: unit-test workflow robustness (empty suites, local shared packages)

### DIFF
--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -101,8 +101,14 @@ jobs:
             src_dir=$(dirname "$test_dir")
             name=$(echo "$src_dir" | tr '/.' '--')
             echo "::group::Running tests in $src_dir"
+            rc=0
             (cd "$src_dir" && PYTHONPATH=".:${layer_paths}${PYTHONPATH:-}" python -m pytest tests/ \
-              --junitxml="$GITHUB_WORKSPACE/test-results/$name-results.xml" --tb=short -v) || failed=1
+              --junitxml="$GITHUB_WORKSPACE/test-results/$name-results.xml" --tb=short -v) || rc=$?
+            if [ "$rc" -eq 5 ]; then
+              echo "::warning::No tests collected in $src_dir (pytest exit 5); treating as skipped."
+            elif [ "$rc" -ne 0 ]; then
+              failed=1
+            fi
             echo "::endgroup::"
           done <<< "${{ steps.discover.outputs.dirs }}"
           exit $failed


### PR DESCRIPTION
## Description
Two robustness fixes for the shared python-unit-tests workflow, both surfaced by the iot-* rollout PRs.

## Changes Made
1. Per-suite pytest exit code 5 (no tests collected) now emits a ::warning:: and is treated as skipped instead of failing the job. Scaffold tests/ dirs (empty __init__.py only) were failing CI spuriously: hit in iot-asset-scan-management (#44 needed a placeholder-test workaround), pending in iot-jobs-management (functions/python-sample/tests).
2. New optional `extra-install` input: a pip install target run before the suites, e.g. `./shared`. iot-edge components import the repo-local edge_shared package that no component requirements.txt declares; locally it happens to be globally installed, in CI 7 suites hit ModuleNotFoundError (iot-edge#34).

Verified locally: empty-scaffold dir takes the skip branch, passing suite takes the pass branch; YAML parses.

## Related ADO Item
n/a