### PR TITLE
ci: shared snyk pr-scan and monitor workflows

### DIFF
--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -30,6 +30,8 @@ on:
     secrets:
       SNYK_TOKEN:
         required: true
+      SNYK_AWS_ROLE_ARN:
+        required: true
 
 jobs:
   snyk-monitor:
@@ -41,7 +43,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.SNYK_AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.SNYK_AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Checkout code

--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -1,0 +1,109 @@
+name: Snyk Monitor
+
+on:
+  workflow_call:
+    inputs:
+      project-tag:
+        description: 'Snyk project tag for this repository (e.g. iot-firmware)'
+        required: true
+        type: string
+      team-tag:
+        description: 'Snyk team tag'
+        default: 'JEDI'
+        required: false
+        type: string
+      lifecycle:
+        description: 'Snyk project lifecycle'
+        default: 'production'
+        required: false
+        type: string
+      severity-iac:
+        description: 'Severity threshold for the IaC report'
+        default: 'high'
+        required: false
+        type: string
+      python-version:
+        description: 'Python version for dependency install'
+        default: '3.13'
+        required: false
+        type: string
+    secrets:
+      SNYK_TOKEN:
+        required: true
+
+jobs:
+  snyk-monitor:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.SNYK_AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install boto3 aws-xray-sdk pydantic aws-lambda-powertools
+          find . -name "requirements.txt" \
+            -not -path '*/node_modules/*' -not -path '*/.venv/*' \
+            -not -path '*/test-env/*' -not -path '*/.git/*' \
+            -exec pip install -r {} \;
+
+      - name: Install Snyk CLI
+        run: npm install -g snyk
+
+      - name: Snyk Monitor
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          set +e
+          snyk monitor \
+            --tags=scmhost=github,scmorg=${{ github.repository_owner }},scmrepo=${{ github.event.repository.name }},team=${{ inputs.team-tag }},project=${{ inputs.project-tag }} \
+            --target-reference=${{ github.ref_name }} \
+            --all-projects \
+            --project-lifecycle=${{ inputs.lifecycle }}
+          rc=$?
+          if [ "$rc" -eq 3 ]; then
+            echo "::notice::Snyk Monitor found no supported manifests in this repository; passing."
+            exit 0
+          fi
+          exit $rc
+
+  snyk-iac-report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Snyk CLI
+        run: npm install -g snyk
+
+      - name: Snyk IaC Test and Report
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          set +e
+          snyk iac test --severity-threshold=${{ inputs.severity-iac }} --report \
+            --tags=scmhost=github,scmorg=${{ github.repository_owner }},scmrepo=${{ github.event.repository.name }},team=${{ inputs.team-tag }},project=${{ inputs.project-tag }} \
+            --target-reference=${{ github.ref_name }} \
+            --project-lifecycle=${{ inputs.lifecycle }}
+          rc=$?
+          if [ "$rc" -eq 3 ]; then
+            echo "::notice::Snyk IaC found no supported files in this repository; passing."
+            exit 0
+          fi
+          exit $rc

--- a/.github/workflows/snyk-pr-scan.yml
+++ b/.github/workflows/snyk-pr-scan.yml
@@ -26,6 +26,8 @@ on:
     secrets:
       SNYK_TOKEN:
         required: true
+      SNYK_AWS_ROLE_ARN:
+        required: true
 
 jobs:
   snyk-code-test:
@@ -37,7 +39,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.SNYK_AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.SNYK_AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Checkout code
@@ -73,7 +75,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.SNYK_AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.SNYK_AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Checkout code

--- a/.github/workflows/snyk-pr-scan.yml
+++ b/.github/workflows/snyk-pr-scan.yml
@@ -1,0 +1,134 @@
+name: Snyk PR Scan
+
+on:
+  workflow_call:
+    inputs:
+      severity-code:
+        description: 'Severity threshold for Snyk Code (SAST)'
+        default: 'high'
+        required: false
+        type: string
+      severity-sca:
+        description: 'Severity threshold for Snyk Open Source (SCA)'
+        default: 'critical'
+        required: false
+        type: string
+      severity-iac:
+        description: 'Severity threshold for Snyk IaC'
+        default: 'high'
+        required: false
+        type: string
+      python-version:
+        description: 'Python version for dependency install'
+        default: '3.13'
+        required: false
+        type: string
+    secrets:
+      SNYK_TOKEN:
+        required: true
+
+jobs:
+  snyk-code-test:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.SNYK_AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install Snyk CLI
+        run: npm install -g snyk
+
+      - name: Snyk Code Test
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          set +e
+          snyk code test --severity-threshold=${{ inputs.severity-code }} --all-projects
+          rc=$?
+          if [ "$rc" -eq 3 ]; then
+            echo "::notice::Snyk Code found no supported files in this repository; passing."
+            exit 0
+          fi
+          exit $rc
+
+  snyk-sca-test:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.SNYK_AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install boto3 aws-xray-sdk pydantic aws-lambda-powertools
+          find . -name "requirements.txt" \
+            -not -path '*/node_modules/*' -not -path '*/.venv/*' \
+            -not -path '*/test-env/*' -not -path '*/.git/*' \
+            -exec pip install -r {} \;
+
+      - name: Install Snyk CLI
+        run: npm install -g snyk
+
+      - name: Snyk SCA Test
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          set +e
+          snyk test --severity-threshold=${{ inputs.severity-sca }} --all-projects
+          rc=$?
+          if [ "$rc" -eq 3 ]; then
+            echo "::notice::Snyk SCA found no supported manifests in this repository; passing."
+            exit 0
+          fi
+          exit $rc
+
+  snyk-iac-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Snyk CLI
+        run: npm install -g snyk
+
+      - name: Snyk IaC Test
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          set +e
+          snyk iac test --severity-threshold=${{ inputs.severity-iac }}
+          rc=$?
+          if [ "$rc" -eq 3 ]; then
+            echo "::notice::Snyk IaC found no supported files in this repository; passing."
+            exit 0
+          fi
+          exit $rc


### PR DESCRIPTION
## Description
Consolidates the Snyk workflows copy-pasted in iot-device-management and iot-firmware-management into two reusable workflows for all 7 iot-* repos.

## Changes Made
- snyk-pr-scan.yml: code/SCA/IaC scans, thresholds as inputs (high/critical/high defaults), Snyk CLI invoked directly so exit 3 (no supported files) passes with a notice while vulns/errors fail. AWS OIDC role assumption preserved from the current workflows.
- snyk-monitor.yml: push-to-main monitor + IaC report, per-repo project-tag input (fixes firmware's copy-pasted project=iot-device tag).

## Related ADO Item
[fill in]