### PR TITLE
fix: install Node dependencies before snyk SCA/monitor scans

### DIFF
--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -62,6 +62,14 @@ jobs:
             -not -path '*/node_modules/*' -not -path '*/.venv/*' \
             -not -path '*/test-env/*' -not -path '*/.git/*' \
             -exec pip install -r {} \;
+          find . -name package.json \
+            -not -path '*/node_modules/*' -not -path '*/.git/*' -not -path '*/.terraform/*' \
+            | while IFS= read -r pkg; do
+              dir=$(dirname "$pkg")
+              echo "Installing Node dependencies in $dir"
+              (cd "$dir" && if [ -f package-lock.json ]; then npm ci; else npm install; fi) \
+                || echo "::warning::npm install failed in $dir; snyk will surface it"
+            done
 
       - name: Install Snyk CLI
         run: npm install -g snyk

--- a/.github/workflows/snyk-monitor.yml
+++ b/.github/workflows/snyk-monitor.yml
@@ -67,7 +67,7 @@ jobs:
             | while IFS= read -r pkg; do
               dir=$(dirname "$pkg")
               echo "Installing Node dependencies in $dir"
-              (cd "$dir" && if [ -f package-lock.json ]; then npm ci; else npm install; fi) \
+              (cd "$dir" && if [ -f package-lock.json ]; then npm ci --ignore-scripts; else npm install --ignore-scripts; fi) \
                 || echo "::warning::npm install failed in $dir; snyk will surface it"
             done
 

--- a/.github/workflows/snyk-pr-scan.yml
+++ b/.github/workflows/snyk-pr-scan.yml
@@ -99,7 +99,7 @@ jobs:
             | while IFS= read -r pkg; do
               dir=$(dirname "$pkg")
               echo "Installing Node dependencies in $dir"
-              (cd "$dir" && if [ -f package-lock.json ]; then npm ci; else npm install; fi) \
+              (cd "$dir" && if [ -f package-lock.json ]; then npm ci --ignore-scripts; else npm install --ignore-scripts; fi) \
                 || echo "::warning::npm install failed in $dir; snyk will surface it"
             done
 

--- a/.github/workflows/snyk-pr-scan.yml
+++ b/.github/workflows/snyk-pr-scan.yml
@@ -94,6 +94,14 @@ jobs:
             -not -path '*/node_modules/*' -not -path '*/.venv/*' \
             -not -path '*/test-env/*' -not -path '*/.git/*' \
             -exec pip install -r {} \;
+          find . -name package.json \
+            -not -path '*/node_modules/*' -not -path '*/.git/*' -not -path '*/.terraform/*' \
+            | while IFS= read -r pkg; do
+              dir=$(dirname "$pkg")
+              echo "Installing Node dependencies in $dir"
+              (cd "$dir" && if [ -f package-lock.json ]; then npm ci; else npm install; fi) \
+                || echo "::warning::npm install failed in $dir; snyk will surface it"
+            done
 
       - name: Install Snyk CLI
         run: npm install -g snyk


### PR DESCRIPTION
## Description

slight tweak to https://github.com/MT-JEDI/.github/pull/13

snyk test/monitor --all-projects exits 2 (Missing node_modules folder) on any discovered package.json without installed deps. Hit on iot-account-infrastructure#87 (auth0-authorizer Node Lambda), the only iot-* repo with a tracked Node manifest.

## Changes Made
Both snyk-pr-scan (SCA job) and snyk-monitor install-deps steps now install Node deps for every discovered package.json (excluding node_modules/.git/.terraform): npm ci with a lockfile, npm install without. Install failures emit a ::warning:: and let snyk surface the project error rather than masking it.

## Related ADO Item
n/a