### PR TITLE
ci: coverage ratchet + review-thread draft gate

### DIFF
--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -1,4 +1,10 @@
 name: Python Unit Tests
+# Coverage ratchet: combines per-suite coverage into a repo-wide total and
+# compares it against coverage-baseline.txt at the repo root (absent file =
+# advisory notice only). If a repo uses the test-script input, the script may
+# opt into the ratchet by leaving coverage data files at coverage-data/.coverage.*
+# Note: suites with no collectable tests still count their source at 0% in the
+# repo-wide total (deliberate: untested code drags the ratchet).
 
 on:
   workflow_call:
@@ -68,7 +74,7 @@ jobs:
         if: steps.discover.outputs.found == 'true'
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov pytest-mock pytest-asyncio
+          pip install pytest pytest-cov pytest-mock pytest-asyncio coverage
           find "${{ inputs.test-root }}" -name requirements.txt \
             -not -path '*/node_modules/*' -not -path '*/automation-tests/*' \
             -not -path '*/.venv/*' -not -path '*/test-env/*' -not -path '*/.git/*' \
@@ -86,7 +92,7 @@ jobs:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
         run: |
-          mkdir -p test-results
+          mkdir -p test-results coverage-data
           if [ -n "${{ inputs.test-script }}" ]; then
             bash "${{ inputs.test-script }}"
             exit $?
@@ -102,7 +108,9 @@ jobs:
             name=$(echo "$src_dir" | tr '/.' '--')
             echo "::group::Running tests in $src_dir"
             rc=0
-            (cd "$src_dir" && PYTHONPATH=".:${layer_paths}${PYTHONPATH:-}" python -m pytest tests/ \
+            (cd "$src_dir" && PYTHONPATH=".:${layer_paths}${PYTHONPATH:-}" \
+              COVERAGE_FILE="$GITHUB_WORKSPACE/coverage-data/.coverage.$name" \
+              python -m coverage run --source=. -m pytest tests/ \
               --junitxml="$GITHUB_WORKSPACE/test-results/$name-results.xml" --tb=short -v) || rc=$?
             if [ "$rc" -eq 5 ]; then
               echo "::warning::No tests collected in $src_dir (pytest exit 5); treating as skipped."
@@ -112,6 +120,43 @@ jobs:
             echo "::endgroup::"
           done <<< "${{ steps.discover.outputs.dirs }}"
           exit $failed
+
+      - name: Coverage ratchet
+        if: steps.discover.outputs.found == 'true'
+        run: |
+          if ! ls coverage-data/.coverage.* >/dev/null 2>&1; then
+            echo "::notice::No coverage data produced; coverage ratchet skipped."
+            exit 0
+          fi
+          if ! coverage combine coverage-data/ 2>/dev/null; then
+            echo "::notice::No combinable coverage data; coverage ratchet skipped."
+            exit 0
+          fi
+          if ! coverage json -o coverage-total.json \
+            --omit='*/tests/*,*/test-env/*,*/.venv/*,*/node_modules/*' 2>/dev/null; then
+            echo "::notice::No measurable coverage; coverage ratchet skipped."
+            exit 0
+          fi
+          total=$(python -c "import json; print(round(json.load(open('coverage-total.json'))['totals']['percent_covered'], 1))")
+          echo "Repo-wide unit-test coverage: ${total}%"
+          if [ ! -f coverage-baseline.txt ]; then
+            echo "::notice::No coverage baseline; repo-wide coverage is ${total}%. Commit coverage-baseline.txt (a single number) at the repo root to enable the ratchet."
+            exit 0
+          fi
+          baseline=$(head -n1 coverage-baseline.txt | tr -d '[:space:]')
+          if ! [[ "$baseline" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+            echo "::error::coverage-baseline.txt must contain a single number (found: '${baseline}'). Fix or remove the file."
+            exit 1
+          fi
+          python -c "
+          import sys
+          total, baseline = float('${total}'), float('${baseline}')
+          if total < baseline:
+              print(f'::error::Coverage {total}% is below the baseline {baseline}% (coverage-baseline.txt). Add tests, or lower the baseline in this PR with justification.')
+              sys.exit(1)
+          if total >= baseline + 1.0:
+              print(f'::notice::Coverage rose to {total}% (baseline {baseline}%). Bump coverage-baseline.txt.')
+          "
 
       - name: Publish test results
         if: always() && steps.discover.outputs.found == 'true'

--- a/.github/workflows/review-thread-draft-gate.yml
+++ b/.github/workflows/review-thread-draft-gate.yml
@@ -1,0 +1,86 @@
+name: Review Thread Draft Gate
+
+# Converts a PR back to draft whenever it has unresolved review threads
+# authored by the configured bot login. Never auto-readies a PR; a human
+# always marks ready-for-review. Callers trigger on ready_for_review,
+# review submission, and thread resolve/unresolve events.
+# Optional secret DRAFT_GATE_TOKEN: used instead of GITHUB_TOKEN if the
+# default token cannot run convertPullRequestToDraft.
+
+on:
+  workflow_call:
+    inputs:
+      bot-login:
+        description: 'Login whose unresolved review threads force the PR to draft'
+        default: 'copilot-pull-request-reviewer'
+        required: false
+        type: string
+    secrets:
+      DRAFT_GATE_TOKEN:
+        description: 'Optional token with pull-requests:write for the draft conversion'
+        required: false
+
+jobs:
+  draft-gate:
+    if: github.event.pull_request.draft == false
+    concurrency:
+      group: review-thread-draft-gate-${{ github.repository }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Demote PR to draft when unresolved bot threads exist
+        env:
+          GH_TOKEN: ${{ secrets.DRAFT_GATE_TOKEN || secrets.GITHUB_TOKEN }}
+          BOT_LOGIN: ${{ inputs.bot-login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          owner=${GITHUB_REPOSITORY%/*}
+          name=${GITHUB_REPOSITORY#*/}
+          data=$(gh api graphql -f query='
+            query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  id
+                  isDraft
+                  reviewThreads(first: 100) {
+                    nodes {
+                      isResolved
+                      comments(first: 1) { nodes { author { login } url } }
+                    }
+                  }
+                }
+              }
+            }' -f owner="$owner" -f name="$name" -F number="$PR_NUMBER")
+          is_draft=$(jq -r '.data.repository.pullRequest.isDraft' <<<"$data")
+          pr_id=$(jq -r '.data.repository.pullRequest.id' <<<"$data")
+          mapfile -t urls < <(jq -r --arg bot "$BOT_LOGIN" '
+            .data.repository.pullRequest.reviewThreads.nodes[]
+            | select(.isResolved == false)
+            | select(.comments.nodes[0].author.login == $bot)
+            | .comments.nodes[0].url' <<<"$data")
+          count=${#urls[@]}
+          if [ "$is_draft" = "true" ] || [ "$count" -eq 0 ]; then
+            echo "Nothing to do (draft=$is_draft, unresolved ${BOT_LOGIN} threads=$count)."
+            exit 0
+          fi
+          echo "Demoting PR #$PR_NUMBER to draft: $count unresolved ${BOT_LOGIN} thread(s)."
+          gh api graphql -f query='
+            mutation($id: ID!) {
+              convertPullRequestToDraft(input: {pullRequestId: $id}) {
+                pullRequest { isDraft }
+              }
+            }' -f id="$pr_id"
+          body="<!-- review-thread-draft-gate -->
+          Converted back to **draft**: $count unresolved \`$BOT_LOGIN\` review thread(s). Resolve them (reply + resolve) before marking ready for review.
+          $(printf -- '- %s\n' "${urls[@]}")"
+          existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq '[.[] | select(.body | startswith("<!-- review-thread-draft-gate -->"))][0].id // empty')
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -f body="$body"
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$body"
+          fi

--- a/.github/workflows/review-thread-draft-gate.yml
+++ b/.github/workflows/review-thread-draft-gate.yml
@@ -2,8 +2,11 @@ name: Review Thread Draft Gate
 
 # Converts a PR back to draft whenever it has unresolved review threads
 # authored by the configured bot login. Never auto-readies a PR; a human
-# always marks ready-for-review. Callers trigger on ready_for_review,
-# review submission, and thread resolve/unresolve events.
+# always marks ready-for-review.
+# review submission (pull_request_review: submitted) and PR lifecycle events
+# (pull_request: ready_for_review, reopened, synchronize). Note that
+# pull_request_review_thread is NOT a valid Actions trigger; after resolving
+# threads, the author marks the PR ready again, which re-runs the gate.
 # Optional secret DRAFT_GATE_TOKEN: used instead of GITHUB_TOKEN if the
 # default token cannot run convertPullRequestToDraft.
 

--- a/.github/workflows/review-thread-draft-gate.yml
+++ b/.github/workflows/review-thread-draft-gate.yml
@@ -7,8 +7,8 @@ name: Review Thread Draft Gate
 # (pull_request: ready_for_review, reopened, synchronize). Note that
 # pull_request_review_thread is NOT a valid Actions trigger; after resolving
 # threads, the author marks the PR ready again, which re-runs the gate.
-# Optional secret DRAFT_GATE_TOKEN: used instead of GITHUB_TOKEN if the
-# default token cannot run convertPullRequestToDraft.
+# Optional secrets for draft conversion (tried in order): DRAFT_GATE_TOKEN,
+# SVC_JEDI_CI_PAT, GITHUB_TOKEN (which cannot perform convertPullRequestToDraft).
 
 on:
   workflow_call:
@@ -21,6 +21,9 @@ on:
     secrets:
       DRAFT_GATE_TOKEN:
         description: 'Optional token with pull-requests:write for the draft conversion'
+        required: false
+      SVC_JEDI_CI_PAT:
+        description: 'Existing org CI PAT; used for the draft conversion when DRAFT_GATE_TOKEN is unset'
         required: false
 
 jobs:
@@ -36,7 +39,7 @@ jobs:
     steps:
       - name: Demote PR to draft when unresolved bot threads exist
         env:
-          GH_TOKEN: ${{ secrets.DRAFT_GATE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DRAFT_GATE_TOKEN || secrets.SVC_JEDI_CI_PAT || secrets.GITHUB_TOKEN }}
           BOT_LOGIN: ${{ inputs.bot-login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |

--- a/.github/workflows/review-thread-draft-gate.yml
+++ b/.github/workflows/review-thread-draft-gate.yml
@@ -46,13 +46,17 @@ jobs:
           set -euo pipefail
           owner=${GITHUB_REPOSITORY%/*}
           name=${GITHUB_REPOSITORY#*/}
-          data=$(gh api graphql -f query='
-            query($owner: String!, $name: String!, $number: Int!) {
+          # --paginate walks reviewThreads via $endCursor/pageInfo so PRs with
+          # more than one page of review threads are still checked in full.
+          # --slurp wraps each page's JSON into an outer array.
+          data=$(gh api graphql --paginate --slurp -f query='
+            query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
               repository(owner: $owner, name: $name) {
                 pullRequest(number: $number) {
                   id
                   isDraft
-                  reviewThreads(first: 100) {
+                  reviewThreads(first: 100, after: $endCursor) {
+                    pageInfo { hasNextPage endCursor }
                     nodes {
                       isResolved
                       comments(first: 1) { nodes { author { login } url } }
@@ -61,10 +65,10 @@ jobs:
                 }
               }
             }' -f owner="$owner" -f name="$name" -F number="$PR_NUMBER")
-          is_draft=$(jq -r '.data.repository.pullRequest.isDraft' <<<"$data")
-          pr_id=$(jq -r '.data.repository.pullRequest.id' <<<"$data")
+          is_draft=$(jq -r '.[0].data.repository.pullRequest.isDraft' <<<"$data")
+          pr_id=$(jq -r '.[0].data.repository.pullRequest.id' <<<"$data")
           mapfile -t urls < <(jq -r --arg bot "$BOT_LOGIN" '
-            .data.repository.pullRequest.reviewThreads.nodes[]
+            .[] | .data.repository.pullRequest.reviewThreads.nodes[]
             | select(.isResolved == false)
             | select(.comments.nodes[0].author.login == $bot)
             | .comments.nodes[0].url' <<<"$data")
@@ -80,9 +84,11 @@ jobs:
                 pullRequest { isDraft }
               }
             }' -f id="$pr_id"
-          body="<!-- review-thread-draft-gate -->
-          Converted back to **draft**: $count unresolved \`$BOT_LOGIN\` review thread(s). Resolve them (reply + resolve) before marking ready for review.
-          $(printf -- '- %s\n' "${urls[@]}")"
+          # printf keeps every line flush at column 0; a quoted multi-line
+          # string here would carry the YAML block's leading indentation,
+          # which Markdown renders as a code block (4+ leading spaces).
+          body=$(printf '<!-- review-thread-draft-gate -->\nConverted back to **draft**: %s unresolved `%s` review thread(s). Resolve them (reply + resolve) before marking ready for review.\n%s' \
+            "$count" "$BOT_LOGIN" "$(printf -- '- %s\n' "${urls[@]}")")
           existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
             --jq '[.[] | select(.body | startswith("<!-- review-thread-draft-gate -->"))][0].id // empty')
           if [ -n "$existing" ]; then


### PR DESCRIPTION
Round 3 of the iot-* SDLC effort.

- python-unit-tests.yml: repo-wide coverage ratchet against coverage-baseline.txt (absent file = advisory notice, so existing callers stay green).
- review-thread-draft-gate.yml (new): converts a PR back to draft while unresolved Copilot review threads exist. Callers land in the per-repo round-3 PRs.

Probe results for the draft gate will be posted here before this is marked ready (see plan Task 4).