### PR TITLE
fix: exclude .terraform from unit-test discovery for local parity

### DIFF
--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -44,10 +44,19 @@ jobs:
       - name: Discover test directories
         id: discover
         run: |
+          # .terraform is excluded for parity with the repo-local mirror scripts
+          # (scripts/run-unit-tests.sh), not for this job's benefit: a CI checkout has no
+          # .terraform, since it is gitignored and nothing here runs terraform init, so
+          # the exclusion is a no-op upstream. It matters locally, where a terraform-inited
+          # repo would otherwise run the vendored suites under .terraform/modules/* and
+          # count their uncovered source in the coverage total. Keeping both discovery
+          # lists textually identical is what stops the exclusion being dropped by
+          # syncing one file to the other.
           candidates=$(find "${{ inputs.test-root }}" -type d -name tests \
             -not -path '*/node_modules/*' -not -path '*/.venv/*' \
             -not -path '*/test-env/*' -not -path '*/.git/*' \
-            -not -path '*/automation-tests/*')
+            -not -path '*/automation-tests/*' \
+            -not -path '*/.terraform/*')
           dirs=""
           while IFS= read -r d; do
             [ -z "$d" ] && continue


### PR DESCRIPTION
## What

Adds `-not -path '*/.terraform/*'` to the test-discovery `find` in `python-unit-tests.yml`, with a comment explaining that it is deliberately a no-op here.

## Why

The eight repo-local `scripts/run-unit-tests.sh` mirrors of this workflow need that exclusion to be correct: on a developer machine where `terraform init` has been run, discovery picks up the vendored Python suites under `.terraform/modules/*` and counts their uncovered source in the repo-wide coverage total. One repo read 18.2% locally against its 95.8 baseline.

This job never has a `.terraform` directory, so the exclusion changes nothing about CI behavior. It is here so the two discovery lists stay textually identical, which is what prevents the exclusion from being quietly dropped the next time someone syncs the script to this workflow or vice versa.

## Blast radius

No-op for all callers: the pattern cannot match anything in a fresh checkout, and no repo in the org tracks files under `.terraform/` (verified with `git ls-files '*.terraform/*'` across the iot-*, manufacturing-*, backend-*, connectivity-events and terraform-modules repos).

Paired with one PR per repo adding the same line to `scripts/run-unit-tests.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RjfHogTXaCpr7FUNMgcSv
