### PR TITLE
perf: prune excluded trees during test discovery

### DIFF
--- a/.github/workflows/python-unit-tests.yml
+++ b/.github/workflows/python-unit-tests.yml
@@ -52,11 +52,17 @@ jobs:
           # count their uncovered source in the coverage total. Keeping both discovery
           # lists textually identical is what stops the exclusion being dropped by
           # syncing one file to the other.
-          candidates=$(find "${{ inputs.test-root }}" -type d -name tests \
-            -not -path '*/node_modules/*' -not -path '*/.venv/*' \
-            -not -path '*/test-env/*' -not -path '*/.git/*' \
-            -not -path '*/automation-tests/*' \
-            -not -path '*/.terraform/*')
+          #
+          # The excluded trees are pruned rather than filtered out of the results. Both
+          # forms select the same directories, but -not -path still descends into every
+          # excluded tree while scanning: in the largest repo that cost 8.7s of discovery
+          # per local run against 0.06s pruned. Negligible here (a fresh checkout has no
+          # .venv or .terraform to descend into) and kept identical to the local mirror.
+          # -prune suppresses find's implicit print, hence the explicit -print.
+          candidates=$(find "${{ inputs.test-root }}" \( -path '*/node_modules/*' \
+            -o -path '*/.venv/*' -o -path '*/test-env/*' -o -path '*/.git/*' \
+            -o -path '*/automation-tests/*' -o -path '*/.terraform/*' \) -prune \
+            -o -type d -name tests -print)
           dirs=""
           while IFS= read -r d; do
             [ -z "$d" ] && continue
@@ -109,7 +115,13 @@ jobs:
           layer_paths=""
           while IFS= read -r -d '' p; do
             layer_paths="${GITHUB_WORKSPACE}/${p#./}:${layer_paths}"
-          done < <(find . -type d -path '*/layers/*/python' -not -path '*/node_modules/*' -print0)
+          # Pruned like the discovery find above, and over the same set: besides the
+          # traversal cost, it keeps a vendored layers/*/python (under .terraform in a
+          # local checkout) from reaching PYTHONPATH.
+          done < <(find . \( -path '*/node_modules/*' -o -path '*/.venv/*' \
+            -o -path '*/test-env/*' -o -path '*/.git/*' -o -path '*/automation-tests/*' \
+            -o -path '*/.terraform/*' \) -prune \
+            -o -type d -path '*/layers/*/python' -print0)
           failed=0
           while IFS= read -r test_dir; do
             [ -z "$test_dir" ] && continue


### PR DESCRIPTION
## What

Prunes the excluded trees in both `find`s in `python-unit-tests.yml` (test discovery and `layers/*/python` discovery) instead of filtering them out of the results, over the same exclusion set.

## Why

Paired with one PR per repo making the identical change to `scripts/run-unit-tests.sh`, so the two discovery expressions stay textually identical. The win is local, where `.venv`/`.terraform` exist: discovery in the largest repo went from 8.69s to 0.06s. Here it is effectively free, since a fresh checkout has nothing large to descend into.

The layer `find` moves from excluding only `node_modules` to the same set as the test find, which also stops a vendored `layers/*/python` from reaching `PYTHONPATH` in a checkout that has one.

## Blast radius

- Both finds return byte-identical output in all eight caller repos, verified in a fresh CI-like checkout (no `.venv`/`.terraform`) and in a terraform-inited local checkout.
- `-prune` suppresses `find`'s implicit print, so both finds now carry an explicit `-print`/`-print0`. The equivalence check above covers this.
- Workflow YAML parses and every `run:` block passes `bash -n`.
- Discovery semantics are otherwise untouched: same exclusion set, same `-type d -name tests`, same `.py`-containing filter downstream.

## Stacked

Base is `fix/exclude-terraform-from-test-discovery` (#16); review that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RjfHogTXaCpr7FUNMgcSv
