### PR TITLE
feat: Add automated workflow release tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release Shared Workflows
+
+# Tags a new semver release on every conventional-commit merge to main,
+# then moves the major alias (e.g. v1) to the same commit for consumer pinning.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Semver bump (workflow_dispatch only; push uses the merge commit subject)'
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine semver bump
+        id: bump
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          MANUAL_BUMP: ${{ inputs.bump }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "bump=${MANUAL_BUMP}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          subject="${COMMIT_MSG%%$'\n'*}"
+          if echo "$subject" | grep -qiE 'BREAKING CHANGE|^[^(:]+!(\(|:)|^[^(:]+!: '; then
+            echo "bump=major" >> "$GITHUB_OUTPUT"
+          elif echo "$subject" | grep -qE '^(feat)(\([^)]+\))?!?: '; then
+            echo "bump=minor" >> "$GITHUB_OUTPUT"
+          elif echo "$subject" | grep -qE '^(fix|perf|refactor|build|revert|chore|ci|docs|test)(\([^)]+\))?!?: '; then
+            echo "bump=patch" >> "$GITHUB_OUTPUT"
+          else
+            echo "bump=skip" >> "$GITHUB_OUTPUT"
+            echo "Commit subject does not match conventional commits; skipping release."
+          fi
+
+      - name: Bump version and push tag
+        if: steps.bump.outputs.bump != 'skip'
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: ${{ steps.bump.outputs.bump }}
+          tag_prefix: v
+
+      - name: Move major alias
+        if: steps.bump.outputs.bump != 'skip'
+        run: |
+          set -euo pipefail
+          v="${{ steps.tag.outputs.new_tag }}"
+          major="${v%%.*}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f "$major" "$v"
+          git push -f origin "refs/tags/$major"
+
+      - name: Create GitHub Release
+        if: steps.bump.outputs.bump != 'skip'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.new_tag }}
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
             exit 0
           fi
           subject="${COMMIT_MSG%%$'\n'*}"
-          if echo "$subject" | grep -qiE 'BREAKING CHANGE|^[^(:]+!(\(|:)|^[^(:]+!: '; then
+          if echo "$subject" | grep -qiE 'BREAKING CHANGE|^[a-z]+(\([^)]*\))?!(\(|:)'; then
             echo "bump=major" >> "$GITHUB_OUTPUT"
           elif echo "$subject" | grep -qE '^(feat)(\([^)]+\))?!?: '; then
             echo "bump=minor" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -1,0 +1,10 @@
+name: Validate Pull Request
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  semantic-pr-title:
+    uses: ./.github/workflows/semantic-pr-title.yml

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ uses: MT-JEDI/.github/.github/workflows/<workflow>.yml@v1
 
 | Change type | Example commit | Bump |
 |-------------|----------------|------|
-| Breaking (required input removed/renamed, behavior change) | `feat!: drop deprecated bot-login default` | major (`v2.0.0`, alias `v2`) |
+| Breaking (required input removed/renamed, behavior change) | `feat!: ...` or `feat(scope)!: ...` | major (`v2.0.0`, alias `v2`) |
 | New workflow or optional input | `feat: add timeout input to draft gate` | minor (`v1.1.0`) |
 | Fix or non-breaking tweak | `fix: paginate review thread query` | patch (`v1.0.1`) |
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,44 @@ jobs:
       additional-parameter: value
 ```
 
+## Versioning
+
+Shared workflows are versioned with [SemVer](https://semver.org/) tags. Consumer repos should pin to the **major alias** (currently `@v1`), not `@main`:
+
+```yml
+uses: MT-JEDI/.github/.github/workflows/<workflow>.yml@v1
+```
+
+| Change type | Example commit | Bump |
+|-------------|----------------|------|
+| Breaking (required input removed/renamed, behavior change) | `feat!: drop deprecated bot-login default` | major (`v2.0.0`, alias `v2`) |
+| New workflow or optional input | `feat: add timeout input to draft gate` | minor (`v1.1.0`) |
+| Fix or non-breaking tweak | `fix: paginate review thread query` | patch (`v1.0.1`) |
+
+On every conventional-commit squash merge to `main`, [release.yml](.github/workflows/release.yml):
+
+1. Creates an annotated tag `vX.Y.Z`
+2. Force-moves the major alias `vX` to the same commit (so `@v1` always resolves to the latest v1.x release)
+3. Publishes a GitHub Release with generated notes
+
+PR titles must follow conventional commits (same types as `semantic-pr-title.yml`); merges with non-conventional subjects do not produce a release.
+
+### Initial bootstrap (one-time, maintainer)
+
+Before the first automated release, seed the starting version:
+
+```bash
+git checkout main
+git pull
+git tag -a v1.0.0 -m "Initial release of shared workflows"
+git tag -f v1 v1.0.0
+git push origin v1.0.0 v1
+```
+
+Confirm the repo ruleset allows the release workflow to create and force-push tags (`contents: write` on `GITHUB_TOKEN`).
+
+---
+
 ## Shared Workflows
 
 ### Deploy Build Pipeline
@@ -76,7 +114,7 @@ on:
 
 jobs:
   deploy:
-    uses: MT-JEDI/.github/.github/workflows/deploy-build-pipeline.yml@main
+    uses: MT-JEDI/.github/.github/workflows/deploy-build-pipeline.yml@v1
     secrets: inherit
 ```
 
@@ -85,7 +123,7 @@ jobs:
 ```yml
 jobs:
   deploy:
-    uses: MT-JEDI/.github/.github/workflows/deploy-build-pipeline.yml@main
+    uses: MT-JEDI/.github/.github/workflows/deploy-build-pipeline.yml@v1
     with:
       working_directory: './infra/pipeline'
     secrets: inherit
@@ -118,7 +156,7 @@ on:
 
 jobs:
   label-pr-size:
-    uses: MT-JEDI/.github/.github/workflows/pr-size-labeler.yml@main
+    uses: MT-JEDI/.github/.github/workflows/pr-size-labeler.yml@v1
 ```
 
 ### Customized usage with specific thresholds and settings:
@@ -132,7 +170,7 @@ on:
 
 jobs:
   label-pr-size:
-    uses: MT-JEDI/.github/.github/workflows/pr-size-labeler.yml@main
+    uses: MT-JEDI/.github/.github/workflows/pr-size-labeler.yml@v1
     with:
       xs_max_size: '10'
       s_max_size: '50'


### PR DESCRIPTION
## Description

As a consumer of the workflows, I want to reference a version instead of main, and not have to worry about breaking changes.

## Changes Made

This pull request introduces automated semantic versioning for shared workflows and updates the documentation to guide consumers on proper version pinning. The main addition is a new GitHub Actions workflow (`release.yml`) that creates SemVer tags and maintains a major alias for workflow consumers. The `README.md` is updated to explain the versioning strategy and to change all usage examples to pin shared workflows by major version instead of `@main`.

**Automated Release Workflow:**

* Added `.github/workflows/release.yml` to automate SemVer tagging, major alias management, and GitHub Releases for shared workflows on every conventional-commit merge to `main` or manual trigger.

**Documentation updates:**

* Added a "Versioning" section to `README.md` explaining SemVer usage, commit conventions, and the release automation process, including a one-time bootstrap guide.
* Updated all workflow usage examples in `README.md` to pin to the major version alias (e.g., `@v1`) instead of `@main`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L79-R117) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R126) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L121-R159) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L135-R173)

## Related Issue

None

## Related ADO Item

None

## Checklist

- [x] Code builds without errors
- [x] Code follows the project's code style guidelines
- [ ] Tests were added for any new functionality
- [ ] All tests pass
- [x] Documentation was added/updated if necessary
