### PR TITLE
fix: use commit SHA for major version tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,8 @@ jobs:
           major="${v%%.*}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -f "$major" "$v"
+          # Tag action pushes via the API; the new tag is not in the local ref store yet.
+          git tag -f "$major" "${{ github.sha }}"
           git push -f origin "refs/tags/$major"
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Description

Last one 🤞 . Updating the tag step failed `mathieudutour/github-tag-action` creates and pushes the tag through the GitHub API. The runner's local git never gets that ref, so this line failed:

`git tag -f "$major" "$v" `

<img width="1870" height="794" alt="image" src="https://github.com/user-attachments/assets/4da476eb-cc1b-4465-a95f-443060c93ca6" />

Fix: Tag the major alias from ${{ github.sha }} instead — that's the commit the tag action just tagged:

## Changes Made

Fix the release workflow to tag the major version using the commit SHA instead of the version variable. The tag action pushes via the API, so the new tag isn't yet available in the local ref store, making the version variable reference unreliable.

## Checklist

- [ ] Code builds without errors
- [ ] Code follows the project's code style guidelines
- [ ] Tests were added for any new functionality
- [ ] All tests pass
- [ ] Documentation was added/updated if necessary
